### PR TITLE
Fix compilation error

### DIFF
--- a/inc/medusa/log.hpp
+++ b/inc/medusa/log.hpp
@@ -14,6 +14,7 @@
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/type_traits.hpp>
+#include <unordered_map>
 
 #ifdef _MSC_VER
 # pragma warning(disable: 4251 4275)


### PR DESCRIPTION
/home/ivan/projects/medisa_project/MedusaWillAgo/src/core/log.cpp: In member function ‘bool medusa::LogWrapper::_CheckLogLevel() const’:
/home/ivan/projects/medisa_project/MedusaWillAgo/src/core/log.cpp:63:10: error: ‘unordered_map’ in namespace ‘std’ does not name a type
   static std::unordered_map<std::string, LogLevelType> Str2LogLvl
          ^
/home/ivan/projects/medisa_project/MedusaWillAgo/src/core/log.cpp:74:19: error: ‘Str2LogLvl’ was not declared in this scope
   auto itLogLvl = Str2LogLvl.find(StrLogLvl);
                   ^
