### PR TITLE
Simplify formatting of multiplications when one of the operands is 1.

### DIFF
--- a/src/core/architecture.cpp
+++ b/src/core/architecture.cpp
@@ -217,6 +217,19 @@ public:
 
   virtual Expression::SPType VisitBinaryOperation(BinaryOperationExpression::SPType spBinOpExpr)
   {
+    if (spBinOpExpr->GetOperation() == OperationExpression::OpMul) {
+      auto spLExpr = expr_cast<BitVectorExpression>(spBinOpExpr->GetLeftExpression());
+      auto spRExpr = expr_cast<BitVectorExpression>(spBinOpExpr->GetRightExpression());
+      if ((spLExpr != nullptr) && (spLExpr->GetInt().GetSignedValue() == 1)) {
+        spBinOpExpr->GetRightExpression()->Visit(this);
+        return nullptr;
+      }
+      if ((spRExpr != nullptr) && (spRExpr->GetInt().GetSignedValue() == 1)) {
+        spBinOpExpr->GetLeftExpression()->Visit(this);
+        return nullptr;
+      }
+    }
+
     std::string OpTok = "";
     switch (spBinOpExpr->GetOperation())
     {
@@ -234,6 +247,7 @@ public:
     spBinOpExpr->GetRightExpression()->Visit(this);
     return nullptr;
   }
+
   virtual Expression::SPType VisitBitVector(BitVectorExpression::SPType spConstExpr)
   {
     Address const OprdAddr(spConstExpr->GetInt().ConvertTo<TOffset>());


### PR DESCRIPTION
There are some cases where a register is multiplied by 1 :

```
# disassembly of "\xC7\x04\x24\x18\x00\x00\x00"
mov              dword [esp * 0x0001], 0x0018
```

This commit simplifies the output to this :
`0804847e      mov              dword [esp], 0x0018`
