### PR TITLE
Correctly set type to function in the Label dialog.

### DIFF
--- a/src/tools/qt/LabelDialog.cpp
+++ b/src/tools/qt/LabelDialog.cpp
@@ -41,7 +41,7 @@ void LabelDialog::SetLabel(void)
     LblType |= medusa::Label::String;
   else if (CodeButton->isChecked())
     LblType |= medusa::Label::Code;
-  else if (CodeButton->isChecked())
+  else if (FunctionButton->isChecked())
     LblType |= medusa::Label::Function;
 
   if (LocalButton->isChecked())


### PR DESCRIPTION
Correctly set then type to function when selected in the Label dialog.
